### PR TITLE
Fix the UploadSyncFile API

### DIFF
--- a/lockstep-sdk.nuspec
+++ b/lockstep-sdk.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>LockstepSdk</id>
-		<version>2022.5.7.0</version>
+		<version>2022.5.19.0</version>
 		<title>LockstepSdk</title>
 		<authors>Ted Spence</authors>
 		<owners>Lockstep</owners>
@@ -15,7 +15,7 @@
 		</description>
 		<summary>SDK for the Lockstep Platform API.</summary>
 		<releaseNotes>
-			# 2022.5.7.0
+			# 2022.5.19.0
 			
 
 			For full patch notes see https://developer.lockstep.io

--- a/lockstep-sdk.nuspec
+++ b/lockstep-sdk.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>LockstepSdk</id>
-		<version>2022.4.32.0</version>
+		<version>2022.5.7.0</version>
 		<title>LockstepSdk</title>
 		<authors>Ted Spence</authors>
 		<owners>Lockstep</owners>
@@ -15,7 +15,7 @@
 		</description>
 		<summary>SDK for the Lockstep Platform API.</summary>
 		<releaseNotes>
-			# 2022.4.32.0
+			# 2022.5.7.0
 			
 
 			For full patch notes see https://developer.lockstep.io

--- a/src/LockstepApi.cs
+++ b/src/LockstepApi.cs
@@ -8,7 +8,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.5.7.0
+ * @version    2022.5.19.0
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 
@@ -22,7 +22,7 @@ public class LockstepApi
 {
     // The URL of the environment we will use
     private readonly string _serverUrl;
-    private readonly string _version = "2022.5.7.0";
+    private readonly string _version = "2022.5.19.0";
     private string? _appName;
     private string? _bearerToken;
     private string? _apiKey;
@@ -167,10 +167,11 @@ public class LockstepApi
     /// <param name="path">The URL path fragment relative to this environment</param>
     /// <param name="query">The list of parameters and options to send</param>
     /// <param name="body">The request body to send</param>
+    /// <param name="filename">The filename of a file attachment to upload</param>
     /// <typeparam name="T">The type of the expected response</typeparam>
     /// <returns>The response object including success/failure codes and error messages as appropriate</returns>
     public async Task<LockstepResponse<T>> Request<T>(HttpMethod method, string path,
-        Dictionary<string, object?>? query, object? body)
+        Dictionary<string, object?>? query, object? body, string? filename)
     {
         var request = new HttpRequestMessage();
         request.Method = method;
@@ -217,7 +218,15 @@ public class LockstepApi
         {
             request.Content = new StringContent(JsonSerializer.Serialize(body));
         }
-
+        else if (filename != null)
+        {
+            var bytesFile = await File.ReadAllBytesAsync(filename);
+            var fileContent = new ByteArrayContent(bytesFile);
+            var form = new MultipartFormDataContent(Guid.NewGuid().ToString());
+            form.Add(fileContent, "file", Path.GetFileName(filename));
+            request.Content = form;
+        }
+        
         // Send the request and convert the response into a success or failure
         using (var response = await _client.SendAsync(request))
         {

--- a/src/LockstepApi.cs
+++ b/src/LockstepApi.cs
@@ -8,7 +8,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4.32.0
+ * @version    2022.5.7.0
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 
@@ -22,7 +22,7 @@ public class LockstepApi
 {
     // The URL of the environment we will use
     private readonly string _serverUrl;
-    private readonly string _version = "2022.4.32.0";
+    private readonly string _version = "2022.5.7.0";
     private string? _appName;
     private string? _bearerToken;
     private string? _apiKey;

--- a/src/clients/ActivitiesClient.cs
+++ b/src/clients/ActivitiesClient.cs
@@ -36,7 +36,7 @@ public class ActivitiesClient
         var url = $"/api/v1/Activities/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<ActivityModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<ActivityModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class ActivitiesClient
     public async Task<LockstepResponse<ActivityModel>> UpdateActivity(Guid id, object body)
     {
         var url = $"/api/v1/Activities/{id}";
-        return await _client.Request<ActivityModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<ActivityModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class ActivitiesClient
     public async Task<LockstepResponse<ActivityModel>> DeleteActivity(Guid id)
     {
         var url = $"/api/v1/Activities/{id}";
-        return await _client.Request<ActivityModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActivityModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -78,7 +78,7 @@ public class ActivitiesClient
     public async Task<LockstepResponse<ActivityModel[]>> CreateActivities(ActivityModel[] body)
     {
         var url = $"/api/v1/Activities";
-        return await _client.Request<ActivityModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<ActivityModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public class ActivitiesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<ActivityModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<ActivityModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ public class ActivitiesClient
     public async Task<LockstepResponse<ActivityStreamItemModel[]>> RetrieveActivityStream(Guid id)
     {
         var url = $"/api/v1/Activities/{id}/stream";
-        return await _client.Request<ActivityStreamItemModel[]>(HttpMethod.Get, url, null, null);
+        return await _client.Request<ActivityStreamItemModel[]>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -130,6 +130,6 @@ public class ActivitiesClient
     public async Task<LockstepResponse<ActivityModel>> ForwardActivity(Guid activityId, Guid userId)
     {
         var url = $"/api/v1/Activities/{activityId}/forward/{userId}";
-        return await _client.Request<ActivityModel>(HttpMethod.Post, url, null, null);
+        return await _client.Request<ActivityModel>(HttpMethod.Post, url, null, null, null);
     }
 }

--- a/src/clients/ActivitiesClient.cs
+++ b/src/clients/ActivitiesClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/ApiKeysClient.cs
+++ b/src/clients/ApiKeysClient.cs
@@ -36,7 +36,7 @@ public class ApiKeysClient
         var url = $"/api/v1/ApiKeys/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<ApiKeyModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<ApiKeyModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class ApiKeysClient
     public async Task<LockstepResponse<ApiKeyModel>> RevokeAPIKey(Guid id)
     {
         var url = $"/api/v1/ApiKeys/{id}";
-        return await _client.Request<ApiKeyModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ApiKeyModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -62,7 +62,7 @@ public class ApiKeysClient
     public async Task<LockstepResponse<ApiKeyModel>> CreateAPIKey(ApiKeyModel body)
     {
         var url = $"/api/v1/ApiKeys";
-        return await _client.Request<ApiKeyModel>(HttpMethod.Post, url, null, body);
+        return await _client.Request<ApiKeyModel>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -83,6 +83,6 @@ public class ApiKeysClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<ApiKeyModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<ApiKeyModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/ApiKeysClient.cs
+++ b/src/clients/ApiKeysClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/AppEnrollmentsClient.cs
+++ b/src/clients/AppEnrollmentsClient.cs
@@ -38,7 +38,7 @@ public class AppEnrollmentsClient
         var url = $"/api/v1/AppEnrollments/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<AppEnrollmentModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<AppEnrollmentModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class AppEnrollmentsClient
     public async Task<LockstepResponse<AppEnrollmentModel>> UpdateAppEnrollment(Guid id, object body)
     {
         var url = $"/api/v1/AppEnrollments/{id}";
-        return await _client.Request<AppEnrollmentModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<AppEnrollmentModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ public class AppEnrollmentsClient
         var url = $"/api/v1/AppEnrollments/{id}";
         var options = new Dictionary<string, object?>();
         options["removeEnrollmentData"] = removeEnrollmentData;
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, options, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, options, null, null);
     }
 
     /// <summary>
@@ -87,7 +87,7 @@ public class AppEnrollmentsClient
     public async Task<LockstepResponse<AppEnrollmentModel[]>> CreateAppEnrollments(AppEnrollmentModel[] body)
     {
         var url = $"/api/v1/AppEnrollments";
-        return await _client.Request<AppEnrollmentModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<AppEnrollmentModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -114,7 +114,7 @@ public class AppEnrollmentsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<AppEnrollmentModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<AppEnrollmentModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -131,6 +131,6 @@ public class AppEnrollmentsClient
     public async Task<LockstepResponse<FetchResult<AppEnrollmentCustomFieldModel>>> QueryEnrollmentFields(Guid id)
     {
         var url = $"/api/v1/AppEnrollments/settings/{id}";
-        return await _client.Request<FetchResult<AppEnrollmentCustomFieldModel>>(HttpMethod.Get, url, null, null);
+        return await _client.Request<FetchResult<AppEnrollmentCustomFieldModel>>(HttpMethod.Get, url, null, null, null);
     }
 }

--- a/src/clients/AppEnrollmentsClient.cs
+++ b/src/clients/AppEnrollmentsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/ApplicationsClient.cs
+++ b/src/clients/ApplicationsClient.cs
@@ -38,7 +38,7 @@ public class ApplicationsClient
         var url = $"/api/v1/Applications/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<ApplicationModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<ApplicationModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class ApplicationsClient
     public async Task<LockstepResponse<ApplicationModel>> UpdateApplication(Guid id, object body)
     {
         var url = $"/api/v1/Applications/{id}";
-        return await _client.Request<ApplicationModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<ApplicationModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ public class ApplicationsClient
     public async Task<LockstepResponse<ActionResultModel>> DeleteApplication(Guid id)
     {
         var url = $"/api/v1/Applications/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public class ApplicationsClient
     public async Task<LockstepResponse<ApplicationModel[]>> CreateApplications(ApplicationModel[] body)
     {
         var url = $"/api/v1/Applications";
-        return await _client.Request<ApplicationModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<ApplicationModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -107,6 +107,6 @@ public class ApplicationsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<ApplicationModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<ApplicationModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/ApplicationsClient.cs
+++ b/src/clients/ApplicationsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/AttachmentsClient.cs
+++ b/src/clients/AttachmentsClient.cs
@@ -38,7 +38,7 @@ public class AttachmentsClient
         var url = $"/api/v1/Attachments/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<AttachmentModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<AttachmentModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class AttachmentsClient
     public async Task<LockstepResponse<AttachmentModel>> UpdateAttachment(Guid id, object body)
     {
         var url = $"/api/v1/Attachments/{id}";
-        return await _client.Request<AttachmentModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<AttachmentModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -71,7 +71,7 @@ public class AttachmentsClient
     public async Task<LockstepResponse<ActionResultModel>> ArchiveAttachment(Guid id)
     {
         var url = $"/api/v1/Attachments/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -86,7 +86,7 @@ public class AttachmentsClient
     public async Task<LockstepResponse<string>> DownloadAttachment(Guid id)
     {
         var url = $"/api/v1/Attachments/{id}/download";
-        return await _client.Request<string>(HttpMethod.Get, url, null, null);
+        return await _client.Request<string>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -99,13 +99,14 @@ public class AttachmentsClient
     /// </summary>
     /// <param name="tableName">The name of the type of object to which this Attachment will be linked</param>
     /// <param name="objectId">The unique ID of the object to which this Attachment will be linked</param>
-    public async Task<LockstepResponse<AttachmentModel[]>> UploadAttachment(string tableName, Guid objectId)
+    /// <param name="filename">The full path of a file to upload to the API</param>
+    public async Task<LockstepResponse<AttachmentModel[]>> UploadAttachment(string tableName, Guid objectId, string filename)
     {
         var url = $"/api/v1/Attachments";
         var options = new Dictionary<string, object?>();
         options["tableName"] = tableName;
         options["objectId"] = objectId;
-        return await _client.Request<AttachmentModel[]>(HttpMethod.Post, url, options, null);
+        return await _client.Request<AttachmentModel[]>(HttpMethod.Post, url, options, null, filename);
     }
 
     /// <summary>
@@ -132,6 +133,6 @@ public class AttachmentsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<AttachmentModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<AttachmentModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/AttachmentsClient.cs
+++ b/src/clients/AttachmentsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/CodeDefinitionsClient.cs
+++ b/src/clients/CodeDefinitionsClient.cs
@@ -36,7 +36,7 @@ public class CodeDefinitionsClient
         var url = $"/api/v1/CodeDefinitions/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<CodeDefinitionModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<CodeDefinitionModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -61,6 +61,6 @@ public class CodeDefinitionsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CodeDefinitionModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CodeDefinitionModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/CodeDefinitionsClient.cs
+++ b/src/clients/CodeDefinitionsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/CompaniesClient.cs
+++ b/src/clients/CompaniesClient.cs
@@ -36,7 +36,7 @@ public class CompaniesClient
         var url = $"/api/v1/Companies/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<CompanyModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<CompanyModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class CompaniesClient
     public async Task<LockstepResponse<CompanyModel>> UpdateCompany(Guid id, object body)
     {
         var url = $"/api/v1/Companies/{id}";
-        return await _client.Request<CompanyModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<CompanyModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ public class CompaniesClient
     public async Task<LockstepResponse<ActionResultModel>> DisableCompany(Guid id)
     {
         var url = $"/api/v1/Companies/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public class CompaniesClient
     public async Task<LockstepResponse<CompanyModel[]>> CreateCompanies(CompanyModel[] body)
     {
         var url = $"/api/v1/Companies";
-        return await _client.Request<CompanyModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<CompanyModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public class CompaniesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CompanyModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CompanyModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -128,7 +128,7 @@ public class CompaniesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CustomerSummaryModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CustomerSummaryModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -139,6 +139,6 @@ public class CompaniesClient
     public async Task<LockstepResponse<CustomerDetailsModel>> RetrieveCustomerDetail(Guid id)
     {
         var url = $"/api/v1/Companies/views/customer-details/{id}";
-        return await _client.Request<CustomerDetailsModel>(HttpMethod.Get, url, null, null);
+        return await _client.Request<CustomerDetailsModel>(HttpMethod.Get, url, null, null, null);
     }
 }

--- a/src/clients/CompaniesClient.cs
+++ b/src/clients/CompaniesClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/ContactsClient.cs
+++ b/src/clients/ContactsClient.cs
@@ -34,7 +34,7 @@ public class ContactsClient
         var url = $"/api/v1/Contacts/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<ContactModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<ContactModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public class ContactsClient
     public async Task<LockstepResponse<ContactModel>> UpdateContact(Guid id, object body)
     {
         var url = $"/api/v1/Contacts/{id}";
-        return await _client.Request<ContactModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<ContactModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class ContactsClient
     public async Task<LockstepResponse<ActionResultModel>> DisableContact(Guid id)
     {
         var url = $"/api/v1/Contacts/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public class ContactsClient
     public async Task<LockstepResponse<ContactModel[]>> CreateContacts(ContactModel[] body)
     {
         var url = $"/api/v1/Contacts";
-        return await _client.Request<ContactModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<ContactModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -97,6 +97,6 @@ public class ContactsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<ContactModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<ContactModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/ContactsClient.cs
+++ b/src/clients/ContactsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/CreditMemoAppliedClient.cs
+++ b/src/clients/CreditMemoAppliedClient.cs
@@ -36,7 +36,7 @@ public class CreditMemoAppliedClient
         var url = $"/api/v1/CreditMemoApplied/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<CreditMemoAppliedModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<CreditMemoAppliedModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class CreditMemoAppliedClient
     public async Task<LockstepResponse<CreditMemoAppliedModel>> UpdateCreditMemoApplication(Guid id, object body)
     {
         var url = $"/api/v1/CreditMemoApplied/{id}";
-        return await _client.Request<CreditMemoAppliedModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<CreditMemoAppliedModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class CreditMemoAppliedClient
     public async Task<LockstepResponse<CreditMemoAppliedModel>> DeleteCreditMemoApplication(Guid id)
     {
         var url = $"/api/v1/CreditMemoApplied/{id}";
-        return await _client.Request<CreditMemoAppliedModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<CreditMemoAppliedModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class CreditMemoAppliedClient
     public async Task<LockstepResponse<CreditMemoAppliedModel[]>> CreateCreditMemoApplications(CreditMemoAppliedModel[] body)
     {
         var url = $"/api/v1/CreditMemoApplied";
-        return await _client.Request<CreditMemoAppliedModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<CreditMemoAppliedModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -99,6 +99,6 @@ public class CreditMemoAppliedClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CreditMemoAppliedModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CreditMemoAppliedModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/CreditMemoAppliedClient.cs
+++ b/src/clients/CreditMemoAppliedClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/CurrenciesClient.cs
+++ b/src/clients/CurrenciesClient.cs
@@ -39,7 +39,7 @@ public class CurrenciesClient
         var options = new Dictionary<string, object?>();
         options["date"] = date;
         options["dataProvider"] = dataProvider;
-        return await _client.Request<CurrencyRateModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<CurrencyRateModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -53,6 +53,6 @@ public class CurrenciesClient
         var url = $"/api/v1/Currencies/bulk";
         var options = new Dictionary<string, object?>();
         options["destinationCurrency"] = destinationCurrency;
-        return await _client.Request<CurrencyRateModel[]>(HttpMethod.Post, url, options, body);
+        return await _client.Request<CurrencyRateModel[]>(HttpMethod.Post, url, options, body, null);
     }
 }

--- a/src/clients/CurrenciesClient.cs
+++ b/src/clients/CurrenciesClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/CustomFieldDefinitionsClient.cs
+++ b/src/clients/CustomFieldDefinitionsClient.cs
@@ -36,7 +36,7 @@ public class CustomFieldDefinitionsClient
         var url = $"/api/v1/CustomFieldDefinitions/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<CustomFieldDefinitionModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<CustomFieldDefinitionModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class CustomFieldDefinitionsClient
     public async Task<LockstepResponse<CustomFieldDefinitionModel>> UpdateFieldDefinition(Guid id, object body)
     {
         var url = $"/api/v1/CustomFieldDefinitions/{id}";
-        return await _client.Request<CustomFieldDefinitionModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<CustomFieldDefinitionModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class CustomFieldDefinitionsClient
     public async Task<LockstepResponse<CustomFieldDefinitionModel>> DeleteFieldDefinition(Guid id)
     {
         var url = $"/api/v1/CustomFieldDefinitions/{id}";
-        return await _client.Request<CustomFieldDefinitionModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<CustomFieldDefinitionModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class CustomFieldDefinitionsClient
     public async Task<LockstepResponse<CustomFieldDefinitionModel[]>> CreateFieldDefinitions(CustomFieldDefinitionModel[] body)
     {
         var url = $"/api/v1/CustomFieldDefinitions";
-        return await _client.Request<CustomFieldDefinitionModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<CustomFieldDefinitionModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -101,6 +101,6 @@ public class CustomFieldDefinitionsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CustomFieldDefinitionModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CustomFieldDefinitionModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/CustomFieldDefinitionsClient.cs
+++ b/src/clients/CustomFieldDefinitionsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/CustomFieldValuesClient.cs
+++ b/src/clients/CustomFieldValuesClient.cs
@@ -37,7 +37,7 @@ public class CustomFieldValuesClient
         var url = $"/api/v1/CustomFieldValues/{definitionId}/{recordKey}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<CustomFieldValueModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<CustomFieldValueModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class CustomFieldValuesClient
     public async Task<LockstepResponse<CustomFieldValueModel>> UpdateField(Guid definitionId, Guid recordKey, object body)
     {
         var url = $"/api/v1/CustomFieldValues/{definitionId}/{recordKey}";
-        return await _client.Request<CustomFieldValueModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<CustomFieldValueModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public class CustomFieldValuesClient
     public async Task<LockstepResponse<ActionResultModel>> DeleteField(Guid definitionId, Guid recordKey)
     {
         var url = $"/api/v1/CustomFieldValues/{definitionId}/{recordKey}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -79,7 +79,7 @@ public class CustomFieldValuesClient
     public async Task<LockstepResponse<CustomFieldValueModel[]>> CreateFields(CustomFieldValueModel[] body)
     {
         var url = $"/api/v1/CustomFieldValues";
-        return await _client.Request<CustomFieldValueModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<CustomFieldValueModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -104,6 +104,6 @@ public class CustomFieldValuesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CustomFieldValueModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CustomFieldValueModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/CustomFieldValuesClient.cs
+++ b/src/clients/CustomFieldValuesClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/DefinitionsClient.cs
+++ b/src/clients/DefinitionsClient.cs
@@ -43,7 +43,7 @@ public class DefinitionsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CountryModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CountryModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public class DefinitionsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<CurrencyModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<CurrencyModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public class DefinitionsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<StateModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<StateModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -114,6 +114,6 @@ public class DefinitionsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<ErpModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<ErpModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/DefinitionsClient.cs
+++ b/src/clients/DefinitionsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/EmailsClient.cs
+++ b/src/clients/EmailsClient.cs
@@ -36,7 +36,7 @@ public class EmailsClient
         var url = $"/api/v1/Emails/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<EmailModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<EmailModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class EmailsClient
     public async Task<LockstepResponse<EmailModel>> UpdateEmail(Guid id, object body)
     {
         var url = $"/api/v1/Emails/{id}";
-        return await _client.Request<EmailModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<EmailModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class EmailsClient
     public async Task<LockstepResponse<ActionResultModel>> DeleteEmail(Guid id)
     {
         var url = $"/api/v1/Emails/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -76,10 +76,10 @@ public class EmailsClient
     /// </summary>
     /// <param name="emailId">The unique ID number of the Email to retrieve.</param>
     /// <param name="nonce">The random nonce applied at time of url creation.</param>
-    public async Task<LockstepResponse<byte[]>> RetrieveEmailLogo(Guid emailId, Guid nonce)
+    public async Task<LockstepResponse<string>> RetrieveEmailLogo(Guid emailId, Guid nonce)
     {
         var url = $"/api/v1/Emails/{emailId}/logo/{nonce}";
-        return await _client.Request<byte[]>(HttpMethod.Get, url, null, null);
+        return await _client.Request<string>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public class EmailsClient
     public async Task<LockstepResponse<EmailModel[]>> CreateEmails(EmailModel[] body)
     {
         var url = $"/api/v1/Emails";
-        return await _client.Request<EmailModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<EmailModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -117,6 +117,6 @@ public class EmailsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<EmailModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<EmailModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/EmailsClient.cs
+++ b/src/clients/EmailsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/InvoiceHistoryClient.cs
+++ b/src/clients/InvoiceHistoryClient.cs
@@ -33,7 +33,7 @@ public class InvoiceHistoryClient
     public async Task<LockstepResponse<FetchResult<InvoiceHistoryModel>>> RetrieveInvoiceHistory(Guid id)
     {
         var url = $"/api/v1/InvoiceHistory/{id}";
-        return await _client.Request<FetchResult<InvoiceHistoryModel>>(HttpMethod.Get, url, null, null);
+        return await _client.Request<FetchResult<InvoiceHistoryModel>>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -56,6 +56,6 @@ public class InvoiceHistoryClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<InvoiceHistoryModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<InvoiceHistoryModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/InvoiceHistoryClient.cs
+++ b/src/clients/InvoiceHistoryClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/InvoicesClient.cs
+++ b/src/clients/InvoicesClient.cs
@@ -36,7 +36,7 @@ public class InvoicesClient
         var url = $"/api/v1/Invoices/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<InvoiceModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<InvoiceModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class InvoicesClient
     public async Task<LockstepResponse<InvoiceModel>> UpdateInvoice(Guid id, object body)
     {
         var url = $"/api/v1/Invoices/{id}";
-        return await _client.Request<InvoiceModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<InvoiceModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class InvoicesClient
     public async Task<LockstepResponse<ActionResultModel>> DeleteInvoice(Guid id)
     {
         var url = $"/api/v1/Invoices/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public class InvoicesClient
     public async Task<LockstepResponse<InvoiceModel[]>> CreateInvoices(InvoiceModel[] body)
     {
         var url = $"/api/v1/Invoices";
-        return await _client.Request<InvoiceModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<InvoiceModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ public class InvoicesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<InvoiceModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<InvoiceModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public class InvoicesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<InvoiceSummaryModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<InvoiceSummaryModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -147,6 +147,6 @@ public class InvoicesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<AtRiskInvoiceSummaryModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<AtRiskInvoiceSummaryModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/InvoicesClient.cs
+++ b/src/clients/InvoicesClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/LeadsClient.cs
+++ b/src/clients/LeadsClient.cs
@@ -33,6 +33,6 @@ public class LeadsClient
     public async Task<LockstepResponse<LeadModel[]>> CreateLeads(LeadModel[] body)
     {
         var url = $"/api/v1/Leads";
-        return await _client.Request<LeadModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<LeadModel[]>(HttpMethod.Post, url, null, body, null);
     }
 }

--- a/src/clients/LeadsClient.cs
+++ b/src/clients/LeadsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/NotesClient.cs
+++ b/src/clients/NotesClient.cs
@@ -36,7 +36,7 @@ public class NotesClient
         var url = $"/api/v1/Notes/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<NoteModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<NoteModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class NotesClient
     public async Task<LockstepResponse<ActionResultModel>> ArchiveNote(Guid id)
     {
         var url = $"/api/v1/Notes/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public class NotesClient
     public async Task<LockstepResponse<NoteModel[]>> CreateNotes(NoteModel[] body)
     {
         var url = $"/api/v1/Notes";
-        return await _client.Request<NoteModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<NoteModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -89,6 +89,6 @@ public class NotesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<NoteModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<NoteModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/NotesClient.cs
+++ b/src/clients/NotesClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/PaymentApplicationsClient.cs
+++ b/src/clients/PaymentApplicationsClient.cs
@@ -36,7 +36,7 @@ public class PaymentApplicationsClient
         var url = $"/api/v1/PaymentApplications/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<PaymentAppliedModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<PaymentAppliedModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class PaymentApplicationsClient
     public async Task<LockstepResponse<PaymentAppliedModel>> UpdatePaymentApplication(Guid id, object body)
     {
         var url = $"/api/v1/PaymentApplications/{id}";
-        return await _client.Request<PaymentAppliedModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<PaymentAppliedModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class PaymentApplicationsClient
     public async Task<LockstepResponse<ActionResultModel>> DeletePaymentApplication(Guid id)
     {
         var url = $"/api/v1/PaymentApplications/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class PaymentApplicationsClient
     public async Task<LockstepResponse<PaymentAppliedModel[]>> CreatePaymentApplications(PaymentAppliedModel[] body)
     {
         var url = $"/api/v1/PaymentApplications";
-        return await _client.Request<PaymentAppliedModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<PaymentAppliedModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -99,6 +99,6 @@ public class PaymentApplicationsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<PaymentAppliedModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<PaymentAppliedModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/PaymentApplicationsClient.cs
+++ b/src/clients/PaymentApplicationsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/PaymentsClient.cs
+++ b/src/clients/PaymentsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/PaymentsClient.cs
+++ b/src/clients/PaymentsClient.cs
@@ -36,7 +36,7 @@ public class PaymentsClient
         var url = $"/api/v1/Payments/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<PaymentModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<PaymentModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class PaymentsClient
     public async Task<LockstepResponse<PaymentModel>> UpdatePayment(Guid id, object body)
     {
         var url = $"/api/v1/Payments/{id}";
-        return await _client.Request<PaymentModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<PaymentModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class PaymentsClient
     public async Task<LockstepResponse<ActionResultModel>> DeletePayment(Guid id)
     {
         var url = $"/api/v1/Payments/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -78,7 +78,7 @@ public class PaymentsClient
     public async Task<LockstepResponse<PaymentModel[]>> CreatePayments(PaymentModel[] body)
     {
         var url = $"/api/v1/Payments";
-        return await _client.Request<PaymentModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<PaymentModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public class PaymentsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<PaymentModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<PaymentModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -128,7 +128,7 @@ public class PaymentsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<PaymentSummaryModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<PaymentSummaryModel>>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -138,7 +138,7 @@ public class PaymentsClient
     public async Task<LockstepResponse<PaymentDetailHeaderModel>> RetrievePaymentDetailHeader()
     {
         var url = $"/api/v1/Payments/views/detail-header";
-        return await _client.Request<PaymentDetailHeaderModel>(HttpMethod.Get, url, null, null);
+        return await _client.Request<PaymentDetailHeaderModel>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -161,6 +161,6 @@ public class PaymentsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<PaymentDetailModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<PaymentDetailModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/ProvisioningClient.cs
+++ b/src/clients/ProvisioningClient.cs
@@ -31,7 +31,7 @@ public class ProvisioningClient
     public async Task<LockstepResponse<ProvisioningResponseModel>> ProvisionUserAccount(ProvisioningModel body)
     {
         var url = $"/api/v1/Provisioning";
-        return await _client.Request<ProvisioningResponseModel>(HttpMethod.Post, url, null, body);
+        return await _client.Request<ProvisioningResponseModel>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -42,17 +42,12 @@ public class ProvisioningClient
     public async Task<LockstepResponse<ProvisioningResponseModel>> FinalizeUserAccountProvisioning(ProvisioningFinalizeRequestModel body)
     {
         var url = $"/api/v1/Provisioning/finalize";
-        return await _client.Request<ProvisioningResponseModel>(HttpMethod.Post, url, null, body);
+        return await _client.Request<ProvisioningResponseModel>(HttpMethod.Post, url, null, body, null);
     }
 
-    /// <summary>
-    ///
-    ///
-    /// </summary>
-    /// <param name="body"></param>
     public async Task<LockstepResponse<ActionResultModel>> ProvisionFreeDeveloperAccount(DeveloperAccountSubmitModel body)
     {
         var url = $"/api/v1/Provisioning/free-account";
-        return await _client.Request<ActionResultModel>(HttpMethod.Post, url, null, body);
+        return await _client.Request<ActionResultModel>(HttpMethod.Post, url, null, body, null);
     }
 }

--- a/src/clients/ProvisioningClient.cs
+++ b/src/clients/ProvisioningClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/ReportsClient.cs
+++ b/src/clients/ReportsClient.cs
@@ -35,7 +35,7 @@ public class ReportsClient
         var url = $"/api/v1/Reports/cashflow";
         var options = new Dictionary<string, object?>();
         options["timeframe"] = timeframe;
-        return await _client.Request<CashflowReportModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<CashflowReportModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public class ReportsClient
     public async Task<LockstepResponse<DailySalesOutstandingReportModel[]>> DailySalesOutstanding()
     {
         var url = $"/api/v1/Reports/dailysalesoutstanding";
-        return await _client.Request<DailySalesOutstandingReportModel[]>(HttpMethod.Get, url, null, null);
+        return await _client.Request<DailySalesOutstandingReportModel[]>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public class ReportsClient
     public async Task<LockstepResponse<RiskRateModel[]>> RiskRates()
     {
         var url = $"/api/v1/Reports/riskrates";
-        return await _client.Request<RiskRateModel[]>(HttpMethod.Get, url, null, null);
+        return await _client.Request<RiskRateModel[]>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public class ReportsClient
         var options = new Dictionary<string, object?>();
         options["reportDate"] = reportDate;
         options["companyId"] = companyId;
-        return await _client.Request<ArHeaderInfoModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<ArHeaderInfoModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -101,7 +101,7 @@ public class ReportsClient
         options["CurrencyCode"] = CurrencyCode;
         options["CurrencyProvider"] = CurrencyProvider;
         options["Buckets"] = Buckets;
-        return await _client.Request<AgingModel[]>(HttpMethod.Get, url, options, null);
+        return await _client.Request<AgingModel[]>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -113,7 +113,7 @@ public class ReportsClient
     public async Task<LockstepResponse<ArAgingHeaderInfoModel[]>> AccountsReceivableAgingHeader()
     {
         var url = $"/api/v1/Reports/ar-aging-header";
-        return await _client.Request<ArAgingHeaderInfoModel[]>(HttpMethod.Get, url, null, null);
+        return await _client.Request<ArAgingHeaderInfoModel[]>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -128,6 +128,6 @@ public class ReportsClient
         var url = $"/api/v1/Reports/attachments-header";
         var options = new Dictionary<string, object?>();
         options["companyId"] = companyId;
-        return await _client.Request<AttachmentHeaderInfoModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<AttachmentHeaderInfoModel>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/ReportsClient.cs
+++ b/src/clients/ReportsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/StatusClient.cs
+++ b/src/clients/StatusClient.cs
@@ -32,7 +32,7 @@ public class StatusClient
     public async Task<LockstepResponse<StatusModel>> Ping()
     {
         var url = $"/api/v1/Status";
-        return await _client.Request<StatusModel>(HttpMethod.Get, url, null, null);
+        return await _client.Request<StatusModel>(HttpMethod.Get, url, null, null, null);
     }
 
     /// <summary>
@@ -49,6 +49,6 @@ public class StatusClient
         var url = $"/api/v1/Status/testing";
         var options = new Dictionary<string, object?>();
         options["err"] = err;
-        return await _client.Request<TestTimeoutException>(HttpMethod.Get, url, options, null);
+        return await _client.Request<TestTimeoutException>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/StatusClient.cs
+++ b/src/clients/StatusClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/SyncClient.cs
+++ b/src/clients/SyncClient.cs
@@ -33,7 +33,7 @@ public class SyncClient
     public async Task<LockstepResponse<SyncRequestModel>> CreateSync(SyncSubmitModel body)
     {
         var url = $"/api/v1/Sync";
-        return await _client.Request<SyncRequestModel>(HttpMethod.Post, url, null, body);
+        return await _client.Request<SyncRequestModel>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -42,10 +42,11 @@ public class SyncClient
     /// A Sync task represents an action performed by an Application for a particular account.  An Application can provide many different tasks as part of their capabilities.  Sync tasks are executed in the background and will continue running after they are created.  Use one of the creation APIs to request execution of a task. To check on the progress of the task, call GetSync or QuerySync.
     ///
     /// </summary>
-    public async Task<LockstepResponse<SyncRequestModel>> UploadSyncFile()
+    /// <param name="filename">The full path of a file to upload to the API</param>
+    public async Task<LockstepResponse<SyncRequestModel>> UploadSyncFile(string filename)
     {
         var url = $"/api/v1/Sync/zip";
-        return await _client.Request<SyncRequestModel>(HttpMethod.Post, url, null, null);
+        return await _client.Request<SyncRequestModel>(HttpMethod.Post, url, null, null, filename);
     }
 
     /// <summary>
@@ -63,7 +64,7 @@ public class SyncClient
     public async Task<LockstepResponse<SyncRequestModel>> UpdateSync(Guid id, object body)
     {
         var url = $"/api/v1/Sync/{id}";
-        return await _client.Request<SyncRequestModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<SyncRequestModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -79,7 +80,7 @@ public class SyncClient
         var url = $"/api/v1/Sync/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<SyncRequestModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<SyncRequestModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -104,6 +105,6 @@ public class SyncClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<SyncRequestModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<SyncRequestModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/SyncClient.cs
+++ b/src/clients/SyncClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/UserAccountsClient.cs
+++ b/src/clients/UserAccountsClient.cs
@@ -36,7 +36,7 @@ public class UserAccountsClient
         var url = $"/api/v1/UserAccounts/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<UserAccountModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<UserAccountModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class UserAccountsClient
     public async Task<LockstepResponse<UserAccountModel>> UpdateUser(Guid id, object body)
     {
         var url = $"/api/v1/UserAccounts/{id}";
-        return await _client.Request<UserAccountModel>(HttpMethod.Patch, url, null, body);
+        return await _client.Request<UserAccountModel>(HttpMethod.Patch, url, null, body, null);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class UserAccountsClient
     public async Task<LockstepResponse<ActionResultModel>> DisableUser(Guid id)
     {
         var url = $"/api/v1/UserAccounts/{id}";
-        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Delete, url, null, null, null);
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public class UserAccountsClient
         var url = $"/api/v1/UserAccounts/reenable";
         var options = new Dictionary<string, object?>();
         options["id"] = id;
-        return await _client.Request<ActionResultModel>(HttpMethod.Post, url, options, null);
+        return await _client.Request<ActionResultModel>(HttpMethod.Post, url, options, null, null);
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public class UserAccountsClient
     public async Task<LockstepResponse<InviteModel[]>> InviteUser(InviteSubmitModel[] body)
     {
         var url = $"/api/v1/UserAccounts/invite";
-        return await _client.Request<InviteModel[]>(HttpMethod.Post, url, null, body);
+        return await _client.Request<InviteModel[]>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public class UserAccountsClient
         var url = $"/api/v1/UserAccounts/invite";
         var options = new Dictionary<string, object?>();
         options["code"] = code;
-        return await _client.Request<InviteDataModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<InviteDataModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public class UserAccountsClient
     public async Task<LockstepResponse<TransferOwnerModel>> TransferOwner(TransferOwnerSubmitModel body)
     {
         var url = $"/api/v1/UserAccounts/transfer-owner";
-        return await _client.Request<TransferOwnerModel>(HttpMethod.Post, url, null, body);
+        return await _client.Request<TransferOwnerModel>(HttpMethod.Post, url, null, body, null);
     }
 
     /// <summary>
@@ -142,6 +142,6 @@ public class UserAccountsClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<UserAccountModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<UserAccountModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/UserAccountsClient.cs
+++ b/src/clients/UserAccountsClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/clients/UserRolesClient.cs
+++ b/src/clients/UserRolesClient.cs
@@ -34,7 +34,7 @@ public class UserRolesClient
         var url = $"/api/v1/UserRoles/{id}";
         var options = new Dictionary<string, object?>();
         options["include"] = include;
-        return await _client.Request<UserRoleModel>(HttpMethod.Get, url, options, null);
+        return await _client.Request<UserRoleModel>(HttpMethod.Get, url, options, null, null);
     }
 
     /// <summary>
@@ -55,6 +55,6 @@ public class UserRolesClient
         options["order"] = order;
         options["pageSize"] = pageSize;
         options["pageNumber"] = pageNumber;
-        return await _client.Request<FetchResult<UserRoleModel>>(HttpMethod.Get, url, options, null);
+        return await _client.Request<FetchResult<UserRoleModel>>(HttpMethod.Get, url, options, null, null);
     }
 }

--- a/src/clients/UserRolesClient.cs
+++ b/src/clients/UserRolesClient.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 

--- a/src/models/ActionResultModel.cs
+++ b/src/models/ActionResultModel.cs
@@ -14,7 +14,13 @@
 
 namespace LockstepSDK;
 
+/// <summary>
+/// Represents a response to an API action that does not return data
+/// </summary>
 public class ActionResultModel
 {
+    /// <summary>
+    /// A list of messages returned by this API call
+    /// </summary>
     public string[]? Messages { get; internal set; }
 }

--- a/src/models/DataModels.cs
+++ b/src/models/DataModels.cs
@@ -14,6 +14,7 @@
 namespace LockstepSDK;
 
 
+#pragma warning disable CS8618
 
 /// <summary>
 /// An Activity contains information about work being done on a specific accounting task.

--- a/src/models/DataModels.cs
+++ b/src/models/DataModels.cs
@@ -8,7 +8,6 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.4
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 
@@ -16,8 +15,15 @@ namespace LockstepSDK;
 
 
 
+/// <summary>
+/// An Activity contains information about work being done on a specific accounting task.
+/// You can use Activities to track information about who has been assigned a specific task,
+/// the current status of the task, the name and description given for the particular task,
+/// the priority of the task, and any amounts collected, paid, or credited for the task.
+/// </summary>
 public class ActivityModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -185,10 +191,14 @@ public class ActivityModel
     /// To retrieve this collection, specify `References` in the "Include" parameter for your query.
     /// </summary>
     public ActivityXRefModel[]? References { get; set; }
-
 };
+
+/// <summary>
+/// Represents an item belonging to the activity stream.
+/// </summary>
 public class ActivityStreamItemModel
 {
+
     /// <summary>
     /// The object key of the activity stream item.
     /// </summary>
@@ -241,10 +251,11 @@ public class ActivityStreamItemModel
     /// The name of the contact sending the activity otherwise null.
     /// </summary>
     public string? ToContactName { get; set; }
-
 };
+
 public class ActivityXRefModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this is
     /// added to the Lockstep platform.
@@ -273,10 +284,14 @@ public class ActivityXRefModel
     /// The ID of the object the activity reference is associated with
     /// </summary>
     public string? ObjectKey { get; set; }
-
 };
+
+/// <summary>
+/// Represents an aging record
+/// </summary>
 public class AgingModel
 {
+
     /// <summary>
     /// Aging bucket of outstanding balance data (days past due date of invoice)
     /// </summary>
@@ -291,10 +306,20 @@ public class AgingModel
     /// Outstanding balance for the given aging bucket
     /// </summary>
     public double OutstandingBalance { get; set; }
-
 };
+
+/// <summary>
+/// An API Key is an authentication token that you may use with the Lockstep API.  Because API Keys
+/// do not have an expiration date, they are well suited for unattended processes.  Each API Key
+/// is associated with a user, and may be revoked to prevent it from accessing the Lockstep API.
+/// When you create an API Key, make sure to save the value in a secure location.  Lockstep cannot
+/// retrieve an API Key once it is created.
+///
+/// For more information, see [API Keys](https://developer.lockstep.io/docs/api-keys).
+/// </summary>
 public class ApiKeyModel
 {
+
     /// <summary>
     /// The unique identifier for the API key.
     /// </summary>
@@ -358,10 +383,14 @@ public class ApiKeyModel
     /// The UTC datetime when the API key expires.
     /// </summary>
     public DateTime? Expires { get; set; }
-
 };
+
+/// <summary>
+/// App enrollment and custom field merged into one
+/// </summary>
 public class AppEnrollmentCustomFieldModel
 {
+
     /// <summary>
     /// Unique id for the app enrollment
     /// </summary>
@@ -419,10 +448,19 @@ public class AppEnrollmentCustomFieldModel
     /// Number data for field
     /// </summary>
     public double? NumericValue { get; set; }
-
 };
+
+/// <summary>
+/// An AppEnrollment represents an app that has been enrolled to the current account.  When you sign up for an
+/// app using the Lockstep Platform, you obtain an enrollment record for that app.  Example types of apps include
+/// connectors and feature enhancement apps. The App Enrollment object contains information about this app, its
+/// configuration, and settings.
+///
+/// See [Applications and Enrollments](https://developer.lockstep.io/docs/applications-and-enrollments) for more information.
+/// </summary>
 public class AppEnrollmentModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -518,10 +556,22 @@ public class AppEnrollmentModel
     /// Only enter relevant fields for the given connector.
     /// </summary>
     public ConnectorInfoModel? ConnectorInfo { get; set; }
-
 };
+
+/// <summary>
+/// An Application represents a feature available to customers within the Lockstep Platform.  You can create
+/// Applications by working with your Lockstep business development manager and publish them on the platform
+/// so that customers can browse and find your Application on the Lockstep Platform Marketplace.  When a
+/// customer adds an Application to their account, they obtain an AppEnrollment which represents that customer's
+/// instance of this Application.  The customer-specific AppEnrollment contains a customer's configuration data
+/// for the Application, which is not customer-specific.
+///
+/// See [Applications and Enrollments](https://developer.lockstep.io/docs/applications-and-enrollments) for more information.
+/// --swaggerCategory:Platform
+/// </summary>
 public class ApplicationModel
 {
+
     /// <summary>
     /// A unique code identifying this application
     /// </summary>
@@ -623,10 +673,14 @@ public class ApplicationModel
     /// To retrieve this collection, specify `CustomFieldValues` in the "Include" parameter for your query.
     /// </summary>
     public CustomFieldValueModel[]? CustomFieldValues { get; set; }
-
 };
+
+/// <summary>
+/// Aggregated Accounts Receivable Aging information.
+/// </summary>
 public class ArAgingHeaderInfoModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -664,10 +718,14 @@ public class ArAgingHeaderInfoModel
     /// Portion of Total AR this data represents.
     /// </summary>
     public double PercentageOfTotalAr { get; set; }
-
 };
+
+/// <summary>
+/// Aggregated Accounts Receivable information.
+/// </summary>
 public class ArHeaderInfoModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -775,10 +833,14 @@ public class ArHeaderInfoModel
     /// Portion of Total AR that is 90+ days Past due.
     /// </summary>
     public double PercentageOfTotalAr90DaysPastDue { get; set; }
-
 };
+
+/// <summary>
+/// Contains summarized data for an invoice
+/// </summary>
 public class AtRiskInvoiceSummaryModel
 {
+
     /// <summary>
     /// The date of the report
     /// </summary>
@@ -862,10 +924,14 @@ public class AtRiskInvoiceSummaryModel
     /// The ids of the payments associated to this invoice.
     /// </summary>
     public Guid[]? PaymentIds { get; set; }
-
 };
+
+/// <summary>
+/// Aggregated Attachment status information.
+/// </summary>
 public class AttachmentHeaderInfoModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -894,10 +960,14 @@ public class AttachmentHeaderInfoModel
     /// The total number of active attachments associated with the provided GroupKey and CompanyId.
     /// </summary>
     public int TotalActive { get; set; }
-
 };
+
+/// <summary>
+/// Represents a user uploaded attachment
+/// </summary>
 public class AttachmentModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -963,10 +1033,14 @@ public class AttachmentModel
     /// Id of the user who made the file
     /// </summary>
     public Guid CreatedUserId { get; set; }
-
 };
+
+/// <summary>
+/// Input format used for bulk conversion route
+/// </summary>
 public class BulkCurrencyConversionModel
 {
+
     /// <summary>
     /// The date for the currency rate
     /// </summary>
@@ -976,10 +1050,14 @@ public class BulkCurrencyConversionModel
     /// The currency code This will be validated by the /api/v1/currencies data set
     /// </summary>
     public string SourceCurrency { get; set; }
-
 };
+
+/// <summary>
+/// Represents the cashflow report based on a timeframe
+/// </summary>
 public class CashflowReportModel
 {
+
     /// <summary>
     /// Timeframe in days the cashflow report is generated on
     /// </summary>
@@ -1004,10 +1082,15 @@ public class CashflowReportModel
     /// Number of invoices billed in the timeframe
     /// </summary>
     public int InvoicesBilledCount { get; set; }
-
 };
+
+/// <summary>
+/// Represents a Code Definition.  Codes can be used as shortened, human readable strings.
+/// Additionally, this table can be used to store lists of system values for Lockstep objects.
+/// </summary>
 public class CodeDefinitionModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -1056,10 +1139,18 @@ public class CodeDefinitionModel
     /// The ID of the user who last modified the Code Definition
     /// </summary>
     public Guid ModifiedUserId { get; set; }
-
 };
+
+/// <summary>
+/// A Company represents a customer, a vendor, or a company within the organization of the account holder.
+/// Companies can have parents and children, representing an organizational hierarchy of corporate entities.
+/// You can use Companies to track projects and financial data under this Company label.
+///
+/// See [Vendors, Customers, and Companies](https://developer.lockstep.io/docs/companies-customers-and-vendors) for more information.
+/// </summary>
 public class CompanyModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -1071,7 +1162,7 @@ public class CompanyModel
     /// <summary>
     /// The short name of the company.
     /// </summary>
-    public string? CompanyName { get; set; }
+    public string CompanyName { get; set; }
 
     /// <summary>
     /// The unique ID of this record as it was known in its originating financial system.
@@ -1318,10 +1409,15 @@ public class CompanyModel
     /// To retrieve this collection, specify `Classification` in the "Include" parameter for your query.
     /// </summary>
     public CodeDefinitionModel? CompanyClassificationCodeDefinition { get; set; }
-
 };
+
+/// <summary>
+/// Represents all possible data required to set up an app enrollment for a connector.
+/// Only send required fields for the given connector.
+/// </summary>
 public class ConnectorInfoModel
 {
+
     /// <summary>
     /// The authorization code returned from the first step of the OAuth2 flow
     /// https://oauth.net/2/grant-types/authorization-code/
@@ -1342,10 +1438,17 @@ public class ConnectorInfoModel
     /// The email an email connection is being created for.
     /// </summary>
     public string? Email { get; set; }
-
 };
+
+/// <summary>
+/// A Contact contains information about a person or role within a Company.
+/// You can use Contacts to track information about who is responsible for a specific project,
+/// who handles invoices, or information about which role at a particular customer or
+/// vendor you should speak with about invoices.
+/// </summary>
 public class ContactModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -1511,10 +1614,14 @@ public class ContactModel
     /// To retrieve this collection, specify `Attachments` in the "Include" parameter for your query.
     /// </summary>
     public CustomFieldValueModel[]? CustomFieldValues { get; set; }
-
 };
+
+/// <summary>
+/// Country model for ISO-3166
+/// </summary>
 public class CountryModel
 {
+
     /// <summary>
     /// Name of the country
     /// </summary>
@@ -1574,10 +1681,18 @@ public class CountryModel
     /// A different name for a country
     /// </summary>
     public string? Aliases { get; set; }
-
 };
+
+/// <summary>
+/// Credit Memos reflect credits granted to a customer for various reasons, such as discounts or refunds.
+/// Credit Memos may be applied to Invoices as Payments. When a Credit Memo is applied as payment to an Invoice,
+/// Lockstep creates a Credit Memo Application record to track the amount from the Credit Memo that was applied
+/// as payment to the Invoice. You can examine Credit Memo Application records to track which Invoices were paid
+/// using this Credit.
+/// </summary>
 public class CreditMemoAppliedModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -1678,10 +1793,14 @@ public class CreditMemoAppliedModel
     /// To retrieve this collection, specify `CustomFieldValues` in the "Include" parameter for your query.
     /// </summary>
     public CustomFieldValueModel[]? CustomFieldValues { get; set; }
-
 };
+
+/// <summary>
+/// Contains information about a credit memo invoice
+/// </summary>
 public class CreditMemoInvoiceModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -1746,10 +1865,14 @@ public class CreditMemoInvoiceModel
     /// The remaining balance value of this invoice.
     /// </summary>
     public double? OutstandingBalanceAmount { get; set; }
-
 };
+
+/// <summary>
+/// Represents an ISO-4217 currency code definition
+/// </summary>
 public class CurrencyModel
 {
+
     /// <summary>
     /// Alphabetic code for the given currency
     /// </summary>
@@ -1774,10 +1897,14 @@ public class CurrencyModel
     /// Symbol for the given currency
     /// </summary>
     public string? Symbol { get; set; }
-
 };
+
+/// <summary>
+/// Represents a currency rate for specific currencies and date
+/// </summary>
 public class CurrencyRateModel
 {
+
     /// <summary>
     /// The source currency
     /// </summary>
@@ -1797,10 +1924,14 @@ public class CurrencyRateModel
     /// The currency rate value
     /// </summary>
     public double? CurrencyRate { get; set; }
-
 };
+
+/// <summary>
+/// Contains customer details data
+/// </summary>
 public class CustomerDetailsModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -1903,10 +2034,14 @@ public class CustomerDetailsModel
     /// Customer payments collected
     /// </summary>
     public CustomerDetailsPaymentModel[]? Payments { get; set; }
-
 };
+
+/// <summary>
+/// Customer payment collected information
+/// </summary>
 public class CustomerDetailsPaymentModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -1959,10 +2094,14 @@ public class CustomerDetailsPaymentModel
     /// Amount payment was made for
     /// </summary>
     public double PaymentAmount { get; set; }
-
 };
+
+/// <summary>
+/// Contains summarized data for a customer
+/// </summary>
 public class CustomerSummaryModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -2040,10 +2179,19 @@ public class CustomerSummaryModel
     /// The date stamp for the newest Activity on this Customer.
     /// </summary>
     public DateTime? NewestActivity { get; set; }
-
 };
+
+/// <summary>
+/// A Custom Field represents metadata added to an object within the Lockstep Platform.  Lockstep provides a
+/// core definition for each object.  The core definition is intended to represent a level of compatibility
+/// that provides support across most accounting systems and products.  When a user or developer requires
+/// information beyond this core definition, you can use Custom Fields to represent this information.
+///
+/// See [Extensibility](https://developer.lockstep.io/docs/extensibility) for more information.
+/// </summary>
 public class CustomFieldDefinitionModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -2107,10 +2255,19 @@ public class CustomFieldDefinitionModel
     /// AppEnrollmentId for this record; used for mapping purposes.
     /// </summary>
     public Guid? AppEnrollmentId { get; set; }
-
 };
+
+/// <summary>
+/// A Custom Field represents metadata added to an object within the Lockstep Platform.  Lockstep provides a
+/// core definition for each object.  The core definition is intended to represent a level of compatibility
+/// that provides support across most accounting systems and products.  When a user or developer requires
+/// information beyond this core definition, you can use Custom Fields to represent this information.
+///
+/// See [Extensibility](https://developer.lockstep.io/docs/extensibility) for more information.
+/// </summary>
 public class CustomFieldValueModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -2138,7 +2295,7 @@ public class CustomFieldValueModel
     /// <summary>
     /// Number data for field
     /// </summary>
-    public double NumericValue { get; set; }
+    public double? NumericValue { get; set; }
 
     /// <summary>
     /// Date created
@@ -2169,10 +2326,14 @@ public class CustomFieldValueModel
     /// Definition of the value
     /// </summary>
     public CustomFieldDefinitionModel? CustomFieldDefinition { get; set; }
-
 };
+
+/// <summary>
+/// Represents the daily sales outstanding report
+/// </summary>
 public class DailySalesOutstandingReportModel
 {
+
     /// <summary>
     /// Timeframe (month) the daily sales outstanding values are associated with
     /// </summary>
@@ -2187,10 +2348,14 @@ public class DailySalesOutstandingReportModel
     /// Time (in days) between an invoice was completed paid off and when the invoice was issued
     /// </summary>
     public double DailySalesOutstanding { get; set; }
-
 };
+
+/// <summary>
+/// Model containing information to create a new developer account.
+/// </summary>
 public class DeveloperAccountSubmitModel
 {
+
     /// <summary>
     /// The name of the developer.
     /// </summary>
@@ -2205,10 +2370,17 @@ public class DeveloperAccountSubmitModel
     /// The company name of the developer.
     /// </summary>
     public string CompanyName { get; set; }
-
 };
+
+/// <summary>
+/// An Email represents a communication sent from one company to another.  The creator of the email is identified
+/// by the `CompanyId` field, recipient(s) by the `EmailTo` field, and cc recipient(s) by the 'EmailCC' field.
+/// The Email Model represents an email and a number of different metadata attributes related to the creation,
+/// storage, and ownership of the email.
+/// </summary>
 public class EmailModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -2384,10 +2556,15 @@ public class EmailModel
     /// To retrieve this collection, specify `Attachments` in the "Include" parameter for your query.
     /// </summary>
     public CustomFieldValueModel[]? CustomFieldValues { get; set; }
-
 };
+
+/// <summary>
+/// Represents all the possible data sent as a part of the provisioning post.
+/// Only send required fields for the given connector.
+/// </summary>
 public class ErpInfoDataModel
 {
+
     /// <summary>
     /// The authorization code returned from the first step of the OAuth2 flow
     /// https://oauth.net/2/grant-types/authorization-code/
@@ -2403,10 +2580,14 @@ public class ErpInfoDataModel
     /// The redirect uri used for step one of the OAuth2.0 flow.
     /// </summary>
     public string? RedirectUri { get; set; }
-
 };
+
+/// <summary>
+/// Represents the ERP object sent in a provisioning request
+/// </summary>
 public class ErpInfoModel
 {
+
     /// <summary>
     /// The id of the ERP's App
     /// </summary>
@@ -2416,10 +2597,14 @@ public class ErpInfoModel
     /// The data required to store for connector access
     /// </summary>
     public ConnectorInfoModel? Data { get; set; }
-
 };
+
+/// <summary>
+/// Represents unsupported ERP systems
+/// </summary>
 public class ErpModel
 {
+
     /// <summary>
     /// Unique ID for this ERP
     /// </summary>
@@ -2434,10 +2619,14 @@ public class ErpModel
     /// Flag to indicate if ERP is supported
     /// </summary>
     public bool IsSupported { get; set; }
-
 };
+
+/// <summary>
+/// Model containing information about a user for the invite/onboarding process.
+/// </summary>
 public class InviteDataModel
 {
+
     /// <summary>
     /// The email address of the invited user.
     /// </summary>
@@ -2447,10 +2636,14 @@ public class InviteDataModel
     /// The status of the user.
     /// </summary>
     public string? UserStatus { get; set; }
-
 };
+
+/// <summary>
+/// Model from the User invite process
+/// </summary>
 public class InviteModel
 {
+
     /// <summary>
     /// The invited email address
     /// </summary>
@@ -2470,18 +2663,26 @@ public class InviteModel
     /// The error message if the invite was not successful
     /// </summary>
     public string? ErrorMessage { get; set; }
-
 };
+
+/// <summary>
+/// Model to invite a new user to your accounting group
+/// </summary>
 public class InviteSubmitModel
 {
+
     /// <summary>
     /// The email address of the user to invite
     /// </summary>
     public string Email { get; set; }
-
 };
+
+/// <summary>
+/// Represents a single address for an invoice
+/// </summary>
 public class InvoiceAddressModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -2565,10 +2766,16 @@ public class InvoiceAddressModel
     /// The ID number of the user who most recently modified this address.
     /// </summary>
     public Guid? ModifiedUserId { get; set; }
-
 };
+
+/// <summary>
+/// An Invoice represents a bill sent from one company to another.  The Lockstep Platform tracks changes to
+/// each Invoice so that you can observe the changes over time.  You can view the InvoiceHistory list to
+/// monitor and observe the changes of this Invoice and track the dates when changes occurred.
+/// </summary>
 public class InvoiceHistoryModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -2742,10 +2949,14 @@ public class InvoiceHistoryModel
     /// The ID number of the user who most recently modified this invoice.
     /// </summary>
     public Guid? ModifiedUserId { get; set; }
-
 };
+
+/// <summary>
+/// Represents a line in an invoice
+/// </summary>
 public class InvoiceLineModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -2888,10 +3099,19 @@ public class InvoiceLineModel
     /// To retrieve this collection, specify `Attachments` in the "Include" parameter for your query.
     /// </summary>
     public AttachmentModel[]? Attachments { get; set; }
-
 };
+
+/// <summary>
+/// An Invoice represents a bill sent from one company to another.  The creator of the invoice is identified
+/// by the `CompanyId` field, and the recipient of the invoice is identified by the `CustomerId` field.  Most
+/// invoices are uniquely identified both by a Lockstep Platform ID number and a customer ERP "key" that was
+/// generated by the system that originated the invoice.  Invoices have a total amount and a due date, and when
+/// some payments have been made on the Invoice the `TotalAmount` and the `OutstandingBalanceAmount` may be
+/// different.
+/// </summary>
 public class InvoiceModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3145,10 +3365,14 @@ public class InvoiceModel
     /// All custom field definitions
     /// </summary>
     public CustomFieldDefinitionModel[]? CustomFieldDefinitions { get; set; }
-
 };
+
+/// <summary>
+/// View to return Payment Detail information for a given Invoice record.
+/// </summary>
 public class InvoicePaymentDetailModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3202,10 +3426,14 @@ public class InvoicePaymentDetailModel
     /// The remaining balance value of this Payment.
     /// </summary>
     public double? UnappliedAmount { get; set; }
-
 };
+
+/// <summary>
+/// Contains summarized data for an invoice
+/// </summary>
 public class InvoiceSummaryModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3284,10 +3512,14 @@ public class InvoiceSummaryModel
     /// The ids of the payments associated to this invoice.
     /// </summary>
     public Guid[]? PaymentIds { get; set; }
-
 };
+
+/// <summary>
+/// Represents leads for creating new ERP connectors
+/// </summary>
 public class LeadModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -3313,10 +3545,19 @@ public class LeadModel
     /// Requested ERP of lead
     /// </summary>
     public string? ErpSystem { get; set; }
-
 };
+
+/// <summary>
+/// A note is a customizable text string that can be attached to various account attributes
+/// within Lockstep. You can use notes for internal communication, correspondence with
+/// clients, or personal reminders. The Note Model represents a note and a number of
+/// different metadata attributes related to the creation, storage, and ownership of the note.
+///
+/// See [Extensibility](https://developer.lockstep.io/docs/extensibility) for more information.
+/// </summary>
 public class NoteModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -3380,10 +3621,17 @@ public class NoteModel
     /// The person to whom this note is intended for.
     /// </summary>
     public string? RecipientName { get; set; }
-
 };
+
+/// <summary>
+/// A Payment Application is created by a business who receives a Payment from a customer.  A customer may make
+/// a single Payment to match an Invoice exactly, a partial Payment for an Invoice, or a single Payment may be
+/// made for multiple smaller Invoices.  The Payment Application contains information about which Invoices are connected
+/// to which Payments and for which amounts.
+/// </summary>
 public class PaymentAppliedModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3465,10 +3713,14 @@ public class PaymentAppliedModel
     /// The invoice associated with this applied payment.
     /// </summary>
     public InvoiceModel? Invoice { get; set; }
-
 };
+
+/// <summary>
+/// Contains group level payment data.
+/// </summary>
 public class PaymentDetailHeaderModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3501,10 +3753,14 @@ public class PaymentDetailHeaderModel
     /// The number of open invoices.
     /// </summary>
     public int? OpenInvoiceCount { get; set; }
-
 };
+
+/// <summary>
+/// Contains detailed information about a Payment.
+/// </summary>
 public class PaymentDetailModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3617,10 +3873,20 @@ public class PaymentDetailModel
     /// The 2 character country code of the address for the Customer's Primary Contact.
     /// </summary>
     public string? CountryCode { get; set; }
-
 };
+
+/// <summary>
+/// A Payment represents money sent from one company to another.  A single payment may contain payments for
+/// one or more invoices; it is also possible for payments to be made in advance of an invoice, for example,
+/// as a deposit.  The creator of the Payment is identified by the `CustomerId` field, and the recipient of
+/// the Payment is identified by the `CompanyId` field.  Most Payments are uniquely identified both by a
+/// Lockstep Platform ID number and a customer ERP "key" that was generated by the system that originated
+/// the Payment.  Payments that have not been fully applied have a nonzero `UnappliedAmount` value, which
+/// represents a deposit that has been paid and not yet applied to an Invoice.
+/// </summary>
 public class PaymentModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3767,10 +4033,14 @@ public class PaymentModel
     /// To retrieve this collection, specify `CustomFieldValues` in the "Include" parameter for your query.
     /// </summary>
     public CustomFieldValueModel[]? CustomFieldValues { get; set; }
-
 };
+
+/// <summary>
+/// Contains summary information for a Payment
+/// </summary>
 public class PaymentSummaryModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3843,10 +4113,14 @@ public class PaymentSummaryModel
     /// The id of the customer for this payment.
     /// </summary>
     public Guid? CustomerId { get; set; }
-
 };
+
+/// <summary>
+/// Represents the data to finalize onboarding for a user
+/// </summary>
 public class ProvisioningFinalizeRequestModel
 {
+
     /// <summary>
     /// The full name of the user
     /// </summary>
@@ -3871,10 +4145,14 @@ public class ProvisioningFinalizeRequestModel
     /// Optional connector information needed to enroll user to their email connector
     /// </summary>
     public ErpInfoModel? EmailConnector { get; set; }
-
 };
+
+/// <summary>
+/// Represents the data sent during the onboarding flow
+/// </summary>
 public class ProvisioningModel
 {
+
     /// <summary>
     /// The full name of the new user
     /// </summary>
@@ -3884,10 +4162,14 @@ public class ProvisioningModel
     /// The information necessary to enroll the user in their ERP
     /// </summary>
     public ErpInfoModel? Erp { get; set; }
-
 };
+
+/// <summary>
+/// Represents the response to either a successful or failed account provisioning
+/// </summary>
 public class ProvisioningResponseModel
 {
+
     /// <summary>
     /// If provisioning is successful, contains the username of the created user.
     /// </summary>
@@ -3922,10 +4204,14 @@ public class ProvisioningResponseModel
     /// The error message(s).
     /// </summary>
     public string? ErrorMessage { get; set; }
-
 };
+
+/// <summary>
+/// Represents a risk rate calculation for a single month
+/// </summary>
 public class RiskRateModel
 {
+
     /// <summary>
     /// The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
     /// account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -3973,10 +4259,14 @@ public class RiskRateModel
     /// The percentage of all open invoices for the calculation month that are over 90 days based on outstanding balance
     /// </summary>
     public double AtRiskPercentage { get; set; }
-
 };
+
+/// <summary>
+/// State model for ISO-3166-2
+/// </summary>
 public class StateModel
 {
+
     /// <summary>
     /// Name of the state
     /// </summary>
@@ -3991,10 +4281,14 @@ public class StateModel
     /// A different name for a state
     /// </summary>
     public string? Aliases { get; set; }
-
 };
+
+/// <summary>
+/// Represents the status of a user's credentials
+/// </summary>
 public class StatusModel
 {
+
     /// <summary>
     /// If authentication is successful, contains the username of the logged-in user.
     /// </summary>
@@ -4065,10 +4359,14 @@ public class StatusModel
     /// OK if the dependency is working.
     /// </summary>
     public object? Dependencies { get; set; }
-
 };
+
+/// <summary>
+/// Contains information about a sync process for an entity.
+/// </summary>
 public class SyncEntityResultModel
 {
+
     /// <summary>
     /// The number of entities inserted
     /// </summary>
@@ -4093,10 +4391,14 @@ public class SyncEntityResultModel
     /// The errors encountered during sync keyed by ERP key
     /// </summary>
     public object? Errors { get; set; }
-
 };
+
+/// <summary>
+/// Represents a user request to sync data
+/// </summary>
 public class SyncRequestModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -4146,18 +4448,26 @@ public class SyncRequestModel
     /// To retrieve this collection, set `includeDetails` to true in your GET requests.
     /// </summary>
     public object? Details { get; set; }
-
 };
+
+/// <summary>
+/// Model representing information for a sync request
+/// </summary>
 public class SyncSubmitModel
 {
+
     /// <summary>
     /// The identifier of the app enrollment
     /// </summary>
     public Guid AppEnrollmentId { get; set; }
-
 };
+
+/// <summary>
+/// Model from the transfer ownership process.
+/// </summary>
 public class TransferOwnerModel
 {
+
     /// <summary>
     /// The previous owner of the account.
     /// </summary>
@@ -4167,18 +4477,42 @@ public class TransferOwnerModel
     /// The new owner of the account.
     /// </summary>
     public UserAccountModel? NewOwner { get; set; }
-
 };
+
+/// <summary>
+/// Model used to submit a transfer ownership request
+/// </summary>
 public class TransferOwnerSubmitModel
 {
+
     /// <summary>
     /// The ID of the user to transfer ownership to.
     /// </summary>
     public Guid TargetUserId { get; set; }
-
 };
+
+/// <summary>
+/// Represents a Uri for download link
+/// </summary>
+public class UriModel
+{
+
+    /// <summary>
+    /// Represents the download link
+    /// </summary>
+    public Uri? DownloadLink { get; set; }
+};
+
+/// <summary>
+/// A User represents a person who has the ability to authenticate against the Lockstep Platform and use
+/// services such as Lockstep Inbox.  A User is uniquely identified by an Azure identity, and each user must
+/// have an email address defined within their account.  All Users must validate their email to make use of
+/// Lockstep platform services.  Users may have different privileges and access control rights within the
+/// Lockstep Platform.
+/// </summary>
 public class UserAccountModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -4351,10 +4685,14 @@ public class UserAccountModel
     /// To retrieve this collection, specify `AccountingRole` in the "Include" parameter for your query.
     /// </summary>
     public CodeDefinitionModel? AccountingRoleCodeDefinition { get; set; }
-
 };
+
+/// <summary>
+/// Represents a role for a user
+/// </summary>
 public class UserRoleModel
 {
+
     /// <summary>
     /// The unique ID of this record, automatically assigned by Lockstep when this record is
     /// added to the Lockstep platform.
@@ -4393,5 +4731,4 @@ public class UserRoleModel
     /// The ID of the user who last modified the user role
     /// </summary>
     public Guid ModifiedUserId { get; set; }
-
 };

--- a/src/models/ErrorResult.cs
+++ b/src/models/ErrorResult.cs
@@ -43,6 +43,11 @@ public class ErrorResult
     /// If this error corresponds to a specific instance or object, this field indicates which one.
     /// </summary>
     public string? Instance { get; internal set; }
+    
+    /// <summary>
+    /// The full content of the HTTP response
+    /// </summary>
+    public string? Content { get; internal set; }
 }
 
 /// <summary>

--- a/src/models/ErrorResult.cs
+++ b/src/models/ErrorResult.cs
@@ -14,13 +14,40 @@
 
 namespace LockstepSDK;
 
+/// <summary>
+/// Represents a failed API request
+/// </summary>
 public class ErrorResult
 {
+    /// <summary>
+    /// A description of the type of error that occurred.
+    /// </summary>
     public string? Type { get; internal set; }
+    
+    /// <summary>
+    /// A short title describing the error.
+    /// </summary>
     public string? Title { get; internal set; }
+    
+    /// <summary>
+    /// If an error code is applicable, this contains an error number.
+    /// </summary>
     public int? Status { get; internal set; }
+    
+    /// <summary>
+    /// If detailed information about this error is available, this value contains more information.
+    /// </summary>
     public string? Detail { get; internal set; }
+    
+    /// <summary>
+    /// If this error corresponds to a specific instance or object, this field indicates which one.
+    /// </summary>
     public string? Instance { get; internal set; }
 }
 
-public class TestTimeoutException : ErrorResult {}
+/// <summary>
+/// DEPRECATED
+/// </summary>
+public class TestTimeoutException : ErrorResult
+{
+}

--- a/src/models/FetchResult.cs
+++ b/src/models/FetchResult.cs
@@ -14,6 +14,10 @@
 
 namespace LockstepSDK;
 
+/// <summary>
+/// Represents a response to a Query API call
+/// </summary>
+/// <typeparam name="T">The type of records returned by this query</typeparam>
 public class FetchResult<T>
 {
     /// <summary>


### PR DESCRIPTION
This PR changes the swagger generator to handle uploading the sync file correctly. We have to parse, as input, request bodies of type multipart form data. Then we have to detect that the API call is uploading a file and add the segmented part information.