### PR TITLE
Fix parsing of error messages

### DIFF
--- a/lockstep-sdk.nuspec
+++ b/lockstep-sdk.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>LockstepSdk</id>
-		<version>2022.6.48.0</version>
+		<version>2022.6.49.0</version>
 		<title>LockstepSdk</title>
 		<authors>Ted Spence</authors>
 		<owners>Lockstep</owners>
@@ -15,7 +15,7 @@
 		</description>
 		<summary>SDK for the Lockstep Platform API.</summary>
 		<releaseNotes>
-			# 2022.6.48.0
+			# 2022.6.49.0
 			
 
 			For full patch notes see https://developer.lockstep.io

--- a/src/LockstepApi.cs
+++ b/src/LockstepApi.cs
@@ -8,7 +8,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.6.48.0
+ * @version    2022.6.49.0
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 
@@ -28,7 +28,7 @@ namespace LockstepSDK
     {
         // The URL of the environment we will use
         private readonly string _serverUrl;
-        private readonly string _version = "2022.6.48.0";
+        private readonly string _version = "2022.6.49.0";
         private string? _appName;
         private string? _bearerToken;
         private string? _apiKey;
@@ -257,8 +257,24 @@ namespace LockstepSDK
                 else
                 {
                     var errorContent = await response.Content.ReadAsStringAsync();
-                    result.Error = JsonSerializer.Deserialize<ErrorResult>(errorContent, options);
-                    if (result.Error != null) result.Error.Content = errorContent;
+                    if (!String.IsNullOrEmpty(errorContent))
+                    {
+                        try
+                        {
+                            result.Error = JsonSerializer.Deserialize<ErrorResult>(errorContent, options);
+                            if (result.Error != null) result.Error.Content = errorContent;
+                        }
+                        catch { }
+                    }
+
+                    if (result.Error == null)
+                    {
+                        result.Error = new ErrorResult()
+                        {
+                            Title = $"{(int)response.StatusCode} {response.StatusCode}",
+                            Content = errorContent
+                        };
+                    }
                 }
     
                 return result;


### PR DESCRIPTION
In some cases, the SDK receives an empty string in response rather than a JSON object.  This can happen if the API call is prevented by a middleware that avoids returning a correctly formatted error response, if the app or server is nonfunctional, or if a proxy server intercepts the API call. 

Whenever we receive an unparseable error message, we should return a simplified error object based on the HTTP status code.  If appropriate, we can also provide the raw text of the HTTP error message.