### PR TITLE
Allow for custom http client handler in environment constructor

### DIFF
--- a/LockstepApi.nuspec
+++ b/LockstepApi.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>LockstepSdk</id>
-		<version>2023.3.18</version>
+		<version>2023.4.0</version>
 		<title>LockstepSdk</title>
 		<authors>Lockstep Network</authors>
 		<owners>Lockstep, Inc.</owners>
@@ -14,7 +14,7 @@
 		<readme>docs/README.md</readme>
 		<summary>Lockstep Platform SDK for CSharp</summary>
 		<releaseNotes>
-            # 2023.3.18
+            # 2023.4.0
         
             For full patch notes see [Patch Notes](https://medium.com/lockstep-developer/tagged/patch-notes) on the [Lockstep Developer website](https://developer.lockstep.io)
         </releaseNotes>

--- a/src/LockstepApi.cs
+++ b/src/LockstepApi.cs
@@ -246,10 +246,11 @@ namespace LockstepSDK
         /// Internal constructor for the client.  You should always begin with `withEnvironment()`.
         /// </summary>
         /// <param name="customUrl"></param>
-        private LockstepApi(string customUrl)
+        /// <param name="clientHandler">Optional client handler to set custom configuration for HTTP client</param>
+        private LockstepApi(string customUrl, HttpClientHandler clientHandler = null)
         {
             // Add support for HTTP compression
-            var handler = new HttpClientHandler();
+            var handler = clientHandler ?? new HttpClientHandler();
             handler.AutomaticDecompression = DecompressionMethods.GZip;
             
             // We intentionally use a single HttpClient object for the lifetime of this API connection.

--- a/src/LockstepApi.cs
+++ b/src/LockstepApi.cs
@@ -9,7 +9,7 @@
  * @author     Lockstep Network <support@lockstep.io>
  *             
  * @copyright  2021-2023 Lockstep, Inc.
- * @version    2023.3.18
+ * @version    2023.4.0
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-csharp
  */
 
@@ -305,35 +305,37 @@ namespace LockstepSDK
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
             };
         }
-    
+
         /// <summary>
         /// Construct a new API client to target the specific environment.
         /// </summary>
         /// <param name="env">The environment to use, either "prd" for production or "sbx" for sandbox.</param>
+        /// <param name="handler">Optional handler to set specific settings for the HTTP client</param>
         /// <returns>The API client to use</returns>
-        public static LockstepApi WithEnvironment(string env)
+        public static LockstepApi WithEnvironment(string env, HttpClientHandler handler = null)
         {
             switch (env)
             {
                 case "sbx":
-                    return new LockstepApi("https://api.sbx.lockstep.io/");
+                    return new LockstepApi("https://api.sbx.lockstep.io/", handler);
                 case "prd":
-                    return new LockstepApi("https://api.lockstep.io/");
+                    return new LockstepApi("https://api.lockstep.io/", handler);
             }
     
             throw new InvalidOperationException($"Unknown environment: {env}");
         }
-    
+
         /// <summary>
         /// Construct an unsafe client that uses a non-standard server; this can be necessary
         /// when using proxy servers or an API gateway.  Please be careful when using this
         /// mode.  You should prefer to use `WithEnvironment()` instead wherever possible.
         /// </summary>
         /// <param name="unsafeUrl">The custom environment URL to use for this client</param>
+        /// <param name="handler">Optional handler to set specific settings for the HTTP client</param>
         /// <returns>The API client to use</returns>
-        public static LockstepApi WithCustomEnvironment(string unsafeUrl)
+        public static LockstepApi WithCustomEnvironment(string unsafeUrl, HttpClientHandler handler = null)
         {
-            return new LockstepApi(unsafeUrl);
+            return new LockstepApi(unsafeUrl, handler);
         }
         
         /// <summary>

--- a/src/LockstepApi.cs
+++ b/src/LockstepApi.cs
@@ -246,7 +246,7 @@ namespace LockstepSDK
         /// Internal constructor for the client.  You should always begin with `withEnvironment()`.
         /// </summary>
         /// <param name="customUrl"></param>
-        /// <param name="clientHandler">Optional client handler to set custom configuration for HTTP client</param>
+        /// <param name="clientHandler">Optional handler to set specific settings for the HTTP client</param>
         private LockstepApi(string customUrl, HttpClientHandler clientHandler = null)
         {
             // Add support for HTTP compression


### PR DESCRIPTION
Some users are interested in using a proxy to access the LockstepAPI, they will need to be able to add their own config for it. I think allowing a custom `HttpClientHandler` should be good